### PR TITLE
Update to Python 3

### DIFF
--- a/memcacheddump.py
+++ b/memcacheddump.py
@@ -1,37 +1,38 @@
 """
-apt-get install python-memcache
-apt-get install libmemcache-tools
+apt-get install python3-memcache
+apt-get install libmemcached-tools
 """
 #!/usr/bin/python
 import sys
 import memcache
 import subprocess
 import json
+import re
 
 out = "memdump"
 host = "127.0.0.1"
 port = "11211"
 if "-f" in sys.argv:
-	out = sys.argv[sys.argv.index("-f")+1]
+        out = sys.argv[sys.argv.index("-f")+1]
 if "-h" in sys.argv:
-	host = sys.argv[sys.argv.index("-h")+1]
+        host = sys.argv[sys.argv.index("-h")+1]
 if "-p" in sys.argv:
-	port = sys.argv[sys.argv.index("-p")+1]
-print "conecting..."
+        port = sys.argv[sys.argv.index("-p")+1]
+print ("conecting...")
 hostport = host+":"+port
 s = memcache.Client([hostport])
-print "checking keys..."
-output = subprocess.check_output("memcdump --servers="+hostport, shell=True)
-data= output.split('\n')
+print ("checking keys...")
+output = subprocess.check_output("memcdump --servers="+hostport+"|| true", shell=True, text=True)
+data = re.split('\n+', output)
 lista = {}
-for key  in data:
+for key in data:
     if key != '':
         lista[key]=s.get(key)
-        print "dumping "+key+"..."
+        print ("dumping "+key+"...")
 jsonfinal = json.dumps(lista, ensure_ascii=False)
-print "writing output..."
+print ("writing output...")
 fileWrite = open(out, "w")
 fileWrite.write(jsonfinal)
 fileWrite.close()
-print "memcache file created"
-print "finish dump"
+print ("memcache file created")
+print ("finish dump")

--- a/memcachedrestore.py
+++ b/memcachedrestore.py
@@ -1,6 +1,6 @@
 """
-apt-get install python-memcache
-apt-get install libmemcache-tools
+apt-get install python3-memcache
+apt-get install libmemcached-tools
 """
 #!/usr/bin/python
 import sys
@@ -17,15 +17,15 @@ if "-h" in sys.argv:
         host = sys.argv[sys.argv.index("-h")+1]
 if "-p" in sys.argv:
         port = sys.argv[sys.argv.index("-p")+1]
-print "conecting..."
+print ("conecting...")
 s = memcache.Client([host+":"+port])
-print "reading dumpfile..."
+print ("reading dumpfile...")
 c = open(out, 'r').read()
 try:
     decoded = json.loads(c)
     for key in decoded:
         s.set(str(key),str(decoded[key]))
-        print "inserting  "+key+"..."
+        print ("inserting  "+key+"...")
 except (ValueError, KeyError, TypeError):
-    print "JSON format error"
-print "restore finished"
+    print ("JSON format error")
+print ("restore finished")


### PR DESCRIPTION
Regarding
`output = subprocess.check_output("memcdump --servers="+hostport+"|| true", shell=True, text=True)`

Two thoughts:
* This fixes https://github.com/juanber84/memcached-dump/issues/2 since `memcdump` for some odd reason has a non-zero exit code
* This should be migrated to `subprocess.run()` I guess ([see docs](https://docs.python.org/3/library/subprocess.html#subproces.check_output)) but this looks like it's beyond my skill grade for now. We need to ignore the exit code and capture standard output.

I tested with Debian Bullseye Python 3.9.2
